### PR TITLE
Add check to cache before bundle and full path support.

### DIFF
--- a/sources/ejecta/EJApp.h
+++ b/sources/ejecta/EJApp.h
@@ -58,6 +58,8 @@ private:
     EJSharedOpenGLContext *openGLContext;
     static EJApp *ejectaInstance;
 
+    bool doesFileExist(const char *filename);
+
 public:
     jobject assetManager;
     BOOL landscapeMode;

--- a/sources/ejecta/EJCanvas/2D/EJGLProgram2D.cpp
+++ b/sources/ejecta/EJCanvas/2D/EJGLProgram2D.cpp
@@ -46,9 +46,9 @@ void EJGLProgram2D::getUniforms() {
 }
 
 GLint EJGLProgram2D::compileShaderFile(NSString *file, GLenum type) {
-    string cachePath = string(EJApp::instance()->dataBundle) + string("/") + (EJApp::instance()->pathForResource(file))->getCString();
+    NSString *sourcePath = EJApp::instance()->pathForResource(file);
     // Load from cache - /data/data
-    NSString *source = NSString::createWithContentsOfFile((NSStringMake(cachePath))->getCString());
+    NSString *source = NSString::createWithContentsOfFile(sourcePath->getCString());
 
     if (!source) {
         // Check file from data bundle - /assets/EJECTA_APP_FOLDER/
@@ -57,7 +57,7 @@ GLint EJGLProgram2D::compileShaderFile(NSString *file, GLenum type) {
             return 0;
         }
 
-        const char *filename = EJApp::instance()->pathForResource(file)->getCString(); // "dirname/filename.ext";
+        const char *filename = sourcePath->getCString(); // "dirname/filename.ext";
 
         // Open file
         AAsset *asset = AAssetManager_open(EJApp::instance()->aassetManager, filename, AASSET_MODE_UNKNOWN);

--- a/sources/ejecta/EJCanvas/EJBindingImage.cpp
+++ b/sources/ejecta/EJCanvas/EJBindingImage.cpp
@@ -22,8 +22,27 @@ void EJBindingImage::beginLoad() {
 
 void EJBindingImage::load(NSString* sharegroup) {
 
-	NSLOG("Loading Image: %s", path->getCString() );
-	NSString * fullPath = EJApp::instance()->pathForResource(path);
+	NSString * fullPath;
+	// If path is a Data URI, a remote URL or a File URI we don't want to prepend resource paths
+	if(path->hasPrefix("data:")) {
+		NSLOG("Loading Image from Data URI not yet implemented.");
+		fullPath = NULL;
+	} else if(path->hasPrefix("http:") || path->hasPrefix("https:")) {
+		NSLOG("Loading Image from URL not yet implemented.");
+		fullPath = NULL;
+	} else if(path->hasPrefix("file://")) {
+		NSLOG("Loading Image from File URI: %s", path->getCString());
+		size_t prefixLength = strlen("file://");
+		fullPath = path->substringFromIndex(prefixLength);
+	} else if(path->hasPrefix("/")) {
+		// This handles '/data/' or '/storage/' but not 'data/' or 'storage/', user has to prepend a '/' for full path
+		NSLOG("Loading Image from full path: %s", path->getCString());
+		fullPath = path;
+	} else {
+		NSLOG("Loading Image (lazy): %s", path->getCString());
+		fullPath = EJApp::instance()->pathForResource(path);
+	}
+
 	EJTexture * tempTex = new EJTexture(fullPath, sharegroup);
 	tempTex->autorelease();
 	endLoad(tempTex);

--- a/sources/ejecta/EJCocoa/NSString.cpp
+++ b/sources/ejecta/EJCocoa/NSString.cpp
@@ -142,6 +142,28 @@ int NSString::compare(const char * pStr) const
     return strcmp(getCString(), pStr);
 }
 
+bool NSString::hasPrefix(const char *prefix) const {
+    size_t prefixLength = strlen(prefix);
+    size_t stringLength = m_sString.length();
+    return stringLength < prefixLength ? false : strncmp(prefix, m_sString.c_str(), prefixLength) == 0;
+}
+
+NSString* NSString::substringFromIndex(size_t anIndex) const {
+    size_t stringLength = m_sString.length();
+    if (anIndex < 0 || anIndex > stringLength) {
+        NSLOG("NSRangeException - Error, index does not lie within the bounds of the receiver.");
+        return NULL;
+    } else if (anIndex == stringLength) {
+        NSString *pRet = new NSString("");
+        pRet->autorelease();
+        return pRet;
+    }
+
+    NSString *pRet = new NSString(m_sString.substr(anIndex).c_str());
+    pRet->autorelease();
+    return pRet;
+}
+
 NSObject* NSString::copyWithZone(NSZone* pZone)
 {
     NSAssert(pZone == NULL, "NSString should not be inherited.");

--- a/sources/ejecta/EJCocoa/NSString.h
+++ b/sources/ejecta/EJCocoa/NSString.h
@@ -63,6 +63,12 @@ public:
     /** compare to a c string */
     int compare(const char *) const;
 
+    /** Check if the string starts with a certain prefix **/
+    bool hasPrefix(const char *) const;
+
+    /** Returns a new string containing the characters of the receiver from the one at a given index to the end. **/
+    NSString* substringFromIndex(size_t) const;
+
     /* override functions */
     virtual NSObject* copyWithZone(NSZone* pZone);
     virtual bool isEqual(const NSObject* pObject);

--- a/sources/ejecta/EJUtils/EJBindingHttpRequest.cpp
+++ b/sources/ejecta/EJUtils/EJBindingHttpRequest.cpp
@@ -536,11 +536,11 @@ void EJBindingHttpRequest::loadLocalhost() {
     EJBindingEventedBase::triggerEvent(NSStringMake("load"), 0, NULL);
 
     // Check file from cache - /data/data/
-    string cachePath = string(EJApp::instance()->dataBundle) + string("/") + (EJApp::instance()->pathForResource(url))->getCString();
+    NSString *urlPath = EJApp::instance()->pathForResource(url);
     unsigned long size = 0;
     unsigned char *pData = 0;
-    NSLOG("Search data: %s", cachePath.c_str());
-    pData = NSString::createFileData(cachePath.c_str(), "rb", &size);
+    NSLOG("Search data: %s", urlPath->getCString());
+    pData = NSString::createFileData(urlPath->getCString(), "rb", &size);
 
     if (pData) {
         // Data was found
@@ -556,7 +556,7 @@ void EJBindingHttpRequest::loadLocalhost() {
             return;
         }
 
-        const char *filename = (EJApp::instance()->pathForResource(url))->getCString(); // "dirname/filename.ext";
+        const char *filename = urlPath->getCString(); // "dirname/filename.ext";
 
         // Open file
         AAsset *asset = AAssetManager_open(EJApp::instance()->aassetManager, filename, AASSET_MODE_UNKNOWN);


### PR DESCRIPTION
To try the cache, you can add this in EjectaRenderer.java:

``` Java
Utils.copyDatFiles(ctx, dataBundle + "/cache/", "www");
```

In index.js, you can try this:

``` JavaScript
img.src = '/data/data/com.impactjs.ejecta.sample/cache/bg.png';
```

``` JavaScript
img.src = 'file:///data/data/com.impactjs.ejecta.sample/cache/bg.png';
```

``` JavaScript
img.src = 'bg.png';
```
