### PR TITLE
fix fillText and cache width

### DIFF
--- a/project/android/jni/source/ejecta/EJCanvas/2D/EJFont.cpp
+++ b/project/android/jni/source/ejecta/EJCanvas/2D/EJFont.cpp
@@ -121,6 +121,7 @@ void EJFont::drawString(NSString* string, EJCanvasContext* context, float x, flo
 		
 		free(bitmap);}
 	}else{
+		width = texture->width;
 		// Fill or stroke color?
 		EJColorRGBA color = fill ? EJCanvasBlendFillColor(state) : EJCanvasBlendStrokeColor(state);
 


### PR DESCRIPTION
Note: the bug was hidden

To reproduce : 

```
ctx.fillText("mylongtext1", 10 , 0); 
ctx.fillText("short1", 10 , 50);
ctx.fillText("mylongtext1", 10 , 100); 
//the second filltext "mylongtext1" take the size of the "short1" (so it is cropped !)
```

this commit solve this issue ;)
