### PR TITLE
localStorage mapped on android sharedpreferences

### DIFF
--- a/project/android/jni/source/ejecta/EJApp.cpp
+++ b/project/android/jni/source/ejecta/EJApp.cpp
@@ -147,12 +147,12 @@ EJApp::~EJApp()
 
 void EJApp::init(JNIEnv *env, jobject jobj, jobject assetManager, const char* path, int w, int h)
 {
-        env->GetJavaVM(&jvm);
+    env->GetJavaVM(&jvm);
         
-        g_obj = jobj;
+    this->g_obj = env->NewGlobalRef(jobj);
 
-        // Set global pointer to Asset Manager in Java
-        this->aassetManager = AAssetManager_fromJava(env, assetManager);
+    // Set global pointer to Asset Manager in Java
+    this->aassetManager = AAssetManager_fromJava(env, assetManager);
         
 	if (dataBundle) {
 		free(dataBundle);

--- a/project/android/jni/source/ejecta/EJApp.h
+++ b/project/android/jni/source/ejecta/EJApp.h
@@ -49,9 +49,6 @@ class EJApp : public NSObject {
 private:
     BOOL paused;
 
-    JavaVM *jvm;
-    jobject g_obj;
-
     NSDictionary *jsClasses;
     EJTimerCollection *timers;
     long currentTime;
@@ -61,6 +58,8 @@ private:
     bool doesFileExist(const char *filename);
 
 public:
+    JavaVM *jvm;
+    jobject g_obj;
     jobject assetManager;
     BOOL landscapeMode;
     JSGlobalContextRef jsGlobalContext;

--- a/project/android/jni/source/ejecta/EJUtils/EJBindingLocalStorage.cpp
+++ b/project/android/jni/source/ejecta/EJUtils/EJBindingLocalStorage.cpp
@@ -1,5 +1,17 @@
 #include "EJBindingLocalStorage.h"
 
+void EJBindingLocalStorage::initWithContext(JSContextRef ctxp, JSObjectRef obj, size_t argc, const JSValueRef argv[]) {
+	_g_obj = EJApp::instance()->g_obj;
+
+	env = NULL;
+	EJApp::instance()->jvm->GetEnv((void**)&env, JNI_VERSION_1_6);
+
+	jclass tmp  = env->GetObjectClass(_g_obj);
+	javaCallerClass = (jclass)env->NewGlobalRef(tmp);
+
+	env->DeleteLocalRef(tmp);
+}
+
 EJBindingLocalStorage::EJBindingLocalStorage() {
 }
 
@@ -8,37 +20,73 @@ EJBindingLocalStorage::~EJBindingLocalStorage() {
 
 EJ_BIND_FUNCTION(EJBindingLocalStorage, getItem, ctx, argc, argv ) {
 	if( argc < 1 ) return NULL;
-	
-	// NSString * key = JSValueToNSString( ctx, argv[0] );
-	// NSString * value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
-	// return value ? NSStringToJSValue( ctx, value ) : NULL;
-	return NULL;
+
+	NSString * key = JSValueToNSString( ctx, argv[0] );
+	char * val;
+
+	jmethodID methodId_getSharedPref = env->GetMethodID(
+		javaCallerClass,
+		"getSharedPreferences",
+		"(Ljava/lang/String;)Ljava/lang/String;");
+
+	jstring pkey = env->NewStringUTF(key->getCString()); 
+
+	jstring my_java_string = (jstring) env->CallObjectMethod(_g_obj, methodId_getSharedPref, pkey);
+	val = strdup(env->GetStringUTFChars(my_java_string, 0));
+
+	env->DeleteLocalRef(pkey);
+
+	return JSValueMakeString(ctx, JSStringCreateWithUTF8CString(val));
 }
 
 EJ_BIND_FUNCTION(EJBindingLocalStorage, setItem, ctx, argc, argv ) {
 	if( argc < 2 ) return NULL;
-	
-	// NSString * key = JSValueToNSString( ctx, argv[0] );
-	// NSString * value = JSValueToNSString( ctx, argv[1] );
-	
-	// if( !key || !value ) return NULL;
-	// [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
-	// [[NSUserDefaults standardUserDefaults] synchronize];
-	
+
+	NSString * key = JSValueToNSString( ctx, argv[0] );
+	NSString * value = JSValueToNSString( ctx, argv[1] );
+
+	jmethodID methodId_setSharedPref = env->GetMethodID(
+		javaCallerClass,
+		"setSharedPreferences",
+		"(Ljava/lang/String;Ljava/lang/String;)V");
+
+	jstring pkey = env->NewStringUTF(key->getCString()); 
+	jstring pvalue = env->NewStringUTF(value->getCString()); 
+
+	env->CallVoidMethod(_g_obj, methodId_setSharedPref, pkey, pvalue);
+
+	env->DeleteLocalRef(pkey);
+	env->DeleteLocalRef(pvalue);
+
 	return NULL;
 }
 
 EJ_BIND_FUNCTION(EJBindingLocalStorage, removeItem, ctx, argc, argv ) {
 	if( argc < 1 ) return NULL;
 	
-	// NSString * key = JSValueToNSString( ctx, argv[0] );
-	// [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+	NSString * key = JSValueToNSString( ctx, argv[0] );
+	
+	jmethodID methodId_removeSharedPref = env->GetMethodID(
+		javaCallerClass,
+		"removeSharedPreferences",
+		"(Ljava/lang/String;)V");
+
+	jstring pkey = env->NewStringUTF(key->getCString()); 
+
+	env->CallVoidMethod(_g_obj, methodId_removeSharedPref, pkey);
+
+	env->DeleteLocalRef(pkey);
 	
 	return NULL;
 }
 
 EJ_BIND_FUNCTION(EJBindingLocalStorage, clear, ctx, argc, argv ) {
-	//[[NSUserDefaults standardUserDefaults] setPersistentDomain:[NSDictionary dictionary] forName:[[NSBundle mainBundle] bundleIdentifier]];
+	jmethodID methodId_resetSharedPref = env->GetMethodID(
+		javaCallerClass,
+		"resetSharedPreferences",
+		"()V");
+
+	env->CallVoidMethod(_g_obj, methodId_resetSharedPref);
 	return NULL;
 }
 

--- a/project/android/jni/source/ejecta/EJUtils/EJBindingLocalStorage.h
+++ b/project/android/jni/source/ejecta/EJUtils/EJBindingLocalStorage.h
@@ -5,6 +5,11 @@
 
 
 class EJBindingLocalStorage : public EJBindingBase {
+
+private:
+    jobject _g_obj;
+    JNIEnv *env;
+    jclass javaCallerClass;
 	
 public:
 
@@ -13,6 +18,7 @@ public:
 	REFECTION_CLASS_IMPLEMENT_DEFINE(EJBindingLocalStorage);
 
 	virtual string superclass(){ return EJBindingBase::toString();};
+    virtual void initWithContext(JSContextRef ctx, JSObjectRef obj, size_t argc, const JSValueRef argv[]);
 
 	EJ_BIND_FUNCTION_DEFINE(getItem, ctx, argc, argv );
 	EJ_BIND_FUNCTION_DEFINE(setItem, ctx, argc, argv );

--- a/project/android/src/com/impactjs/ejecta/EjectaRenderer.java
+++ b/project/android/src/com/impactjs/ejecta/EjectaRenderer.java
@@ -6,6 +6,7 @@ import javax.microedition.khronos.opengles.GL10;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.opengl.GLSurfaceView.Renderer;
+import android.content.SharedPreferences;
 
 public class EjectaRenderer implements Renderer {
 
@@ -78,4 +79,33 @@ public class EjectaRenderer implements Renderer {
 		public abstract void onCanvasCreated();
 	}
 
+	public void setSharedPreferences (String key , String value) {
+		SharedPreferences settings = mContext.getSharedPreferences(mContext.getPackageName() + "ejectaLocalStorage", 0);
+		SharedPreferences.Editor editor = settings.edit();
+
+		editor.putString(key, value);
+		editor.commit();
+	}
+
+	public void resetSharedPreferences () {
+		SharedPreferences settings = mContext.getSharedPreferences(mContext.getPackageName() + "ejectaLocalStorage", 0);
+		SharedPreferences.Editor editor = settings.edit();
+
+		editor.clear();
+		editor.commit();
+	}
+
+	public void removeSharedPreferences (String key) {
+		SharedPreferences settings = mContext.getSharedPreferences(mContext.getPackageName() + "ejectaLocalStorage", 0);
+		SharedPreferences.Editor editor = settings.edit();
+		
+		editor.remove(key);
+		editor.commit();
+	}
+
+	public String getSharedPreferences (String key) {
+		SharedPreferences settings = mContext.getSharedPreferences(mContext.getPackageName() + "ejectaLocalStorage", 0);
+
+		return settings.getString(key, "");
+	}
 }


### PR DESCRIPTION
The goal of this PR is to add implementation for localStorage binding into Ejecta-X

setItem
getItem
removeItem
clear

are implemented

It uses the SharedPreferences storage of Android (the basic key value storage for mobiles)
(See: http://developer.android.com/reference/android/content/SharedPreferences.html)

Code to test it : 

```
  var score = 42;
  var bestScore = localStorage.getItem("my.bestScore") || 0;

  if (score > bestScore) {
    bestScore = score;
    localStorage.setItem("my.bestScore", score);
  }
```
