### PR TITLE
glDetachShader causes problems on some mobile platforms like Kindle Fire...

### DIFF
--- a/project/android/jni/source/ejecta/EJCanvas/2D/EJGLProgram2D.cpp
+++ b/project/android/jni/source/ejecta/EJCanvas/2D/EJGLProgram2D.cpp
@@ -24,12 +24,11 @@ bool EJGLProgram2D::initWithVertexShader(NSString *vertexShaderFile, NSString *f
 	
 	linkProgram(program);
 
+
 	getUniforms();
 	
-	glDetachShader(program, vertexShader);
+	// Calling glDetachShader on some mobile devices/android versions causes problems, but delete will free memory and mark for deletion appropriately
 	glDeleteShader(vertexShader);
-	
-	glDetachShader(program, fragmentShader);
 	glDeleteShader(fragmentShader);
 
 	return true;


### PR DESCRIPTION
... rev 1. Replaced with glDeleteShader. This is the recommended practice. See the comments on : http://stackoverflow.com/questions/9113154/proper-way-to-delete-glsl-shader
